### PR TITLE
remove skipLine(1) in EventProducer and set stride=NUMBER_THREADS-1

### DIFF
--- a/kafkaProducer/src/main/java/at/ac/uibk/dps/streamprocessingapplications/eventGenerators/KafkaProducer/EventProducer.java
+++ b/kafkaProducer/src/main/java/at/ac/uibk/dps/streamprocessingapplications/eventGenerators/KafkaProducer/EventProducer.java
@@ -36,7 +36,6 @@ public class EventProducer implements Runnable {
     try {
       this.reader =
           new CSVReaderBuilder(new FileReader(filePath))
-              .withSkipLines(1)
               .withCSVParser(new CSVParserBuilder().withSeparator(SEPARATION_CHARACTER).build())
               .build();
 

--- a/kafkaProducer/src/main/java/at/ac/uibk/dps/streamprocessingapplications/eventGenerators/KafkaProducer/Main.java
+++ b/kafkaProducer/src/main/java/at/ac/uibk/dps/streamprocessingapplications/eventGenerators/KafkaProducer/Main.java
@@ -39,7 +39,7 @@ public class Main {
                   unixStartTime,
                   FILE_PATH,
                   i,
-                  THREAD_COUNT,
+                  THREAD_COUNT - 1,
                   KAFKA_TOPIC,
                   kafkaProperties));
       threads.add(thread);


### PR DESCRIPTION
Two changes I propose:

1. Remove first line skipping when reading CSV files: Currently, the code skips the first line of the CSV file, assuming it's a header. However, files created via the ``senmlConverter`` don't contain a header, so this behavior results in the loss of one data record.
2. Adjusting the stride to be ``(THREAD_COUNT-1)`` instead of ``THREAD_COUNT`` because otherwise it seems to be the case that lines are completely skipped.

Just let me know, what you think about these changes.
